### PR TITLE
Implement drag-to-pan camera controls for World Map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,10 +67,43 @@ This is a Vue.js project designed to run in a web browser. See Vue.js style guid
 
 ## Core Components
 
-- World Map: a hexagonal map representing the known world. Explored hexes have an icon designating what they are. Unexplored hexes adjacent to explored hexes are grayed out and only have vague descriptions of what to expect. New hexes are added to the map as more unexplored hexes are explored
-- Area Map: a map representing the individual hex that can be accessed by clicking on the hex. This has features and actions specific to that area.
-- Features: a UI element that lives in the Area Map
-- Resources: a type of currency that can be accrued by the player
-- Magical Items: an item that can be created by combining different resources
-- Explorer: a non-playable character that can equip magical items
-- Skills: actions that Explorers can perform based on the Magical Item they have equipped
+### World Map
+A hexagonal map representing the known world. Explored hexes have an icon designating what they are. Unexplored hexes adjacent to explored hexes are grayed out and only have vague descriptions of what to expect. New hexes are added to the map as more unexplored hexes are explored.
+
+**Implementation Details:**
+- SVG-based rendering for scalable graphics and precise click detection
+- Flat-top hexagons with 30 viewBox unit radius
+- Uses honeycomb-grid library via `useHexGrid` composable for hex math and coordinate conversion
+- Data managed through Pinia `worldMapStore`
+- ViewBox dimensions: 300x300 units base size
+- Responsive sizing: min 750px, max 1200px width; min 750px, max 900px height
+
+**Camera Controls:**
+- Drag-to-pan functionality with mouse events
+- Pan offset tracked in viewBox coordinate space
+- Boundaries automatically calculated from hex tile bounding box plus 50-unit margin
+- Smooth panning with proper screen-to-viewBox coordinate scaling
+- Prevents panning beyond visible hex tiles
+
+**Visual States:**
+- Explored tiles: green fill (#90EE90)
+- Unexplored tiles: gray fill (#CCCCCC)
+- All tiles: dark gray stroke (#333333, 2px width)
+
+### Area Map
+A map representing the individual hex that can be accessed by clicking on the hex. This has features and actions specific to that area.
+
+### Features
+A UI element that lives in the Area Map.
+
+### Resources
+A type of currency that can be accrued by the player.
+
+### Magical Items
+An item that can be created by combining different resources.
+
+### Explorer
+A non-playable character that can equip magical items.
+
+### Skills
+Actions that Explorers can perform based on the Magical Item they have equipped.

--- a/src/components/WorldMap.vue
+++ b/src/components/WorldMap.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useWorldMapStore } from '@/stores/worldMap'
 import { useHexGrid } from '@/composables/useHexGrid'
 import type { HexTile } from '@/types/hex'
@@ -9,6 +9,11 @@ const { hexToPixel } = useHexGrid()
 
 // Hexagon size from HexClass
 const hexRadius = 30
+
+// Pan and drag state
+const panOffset = ref({ x: 0, y: 0 })
+const isDragging = ref(false)
+const dragStart = ref({ x: 0, y: 0 })
 
 /**
  * Calculates the corner points of a flat-top hexagon
@@ -36,19 +41,123 @@ const hexagons = computed(() => {
     return {
       tile,
       points: getHexagonPoints(x, y),
+      center: { x, y },
       fill: tile.explorationStatus === 'explored' ? '#90EE90' : '#CCCCCC',
       stroke: '#333333',
     }
   })
 })
+
+/**
+ * Computed bounding box for pan limits
+ * Includes a margin beyond the outermost hexagons
+ */
+const panBounds = computed(() => {
+  if (hexagons.value.length === 0) {
+    return { minX: -150, maxX: 150, minY: -150, maxY: 150 }
+  }
+
+  // Find the min/max coordinates of all hex centers
+  let minX = Infinity
+  let maxX = -Infinity
+  let minY = Infinity
+  let maxY = -Infinity
+
+  hexagons.value.forEach((hex) => {
+    minX = Math.min(minX, hex.center.x - hexRadius)
+    maxX = Math.max(maxX, hex.center.x + hexRadius)
+    minY = Math.min(minY, hex.center.y - hexRadius)
+    maxY = Math.max(maxY, hex.center.y + hexRadius)
+  })
+
+  // Add margin beyond outermost hexes
+  const margin = 50
+  return {
+    minX: minX - margin,
+    maxX: maxX + margin,
+    minY: minY - margin,
+    maxY: maxY + margin,
+  }
+})
+
+/**
+ * Computed viewBox that incorporates pan offset
+ */
+const viewBox = computed(() => {
+  const baseX = -150 + panOffset.value.x
+  const baseY = -150 + panOffset.value.y
+  const width = 300
+  const height = 300
+  return `${baseX} ${baseY} ${width} ${height}`
+})
+
+/**
+ * Mouse event handlers for drag-to-pan
+ */
+const handleMouseDown = (event: MouseEvent) => {
+  isDragging.value = true
+  dragStart.value = { x: event.clientX, y: event.clientY }
+}
+
+const handleMouseMove = (event: MouseEvent) => {
+  if (!isDragging.value) return
+
+  // Calculate the drag delta in screen pixels
+  const deltaX = event.clientX - dragStart.value.x
+  const deltaY = event.clientY - dragStart.value.y
+
+  // Get the SVG element to calculate the proper scale factor
+  const svg = event.currentTarget as SVGSVGElement
+  const rect = svg.getBoundingClientRect()
+
+  // Calculate scale factor from screen pixels to viewBox units
+  // viewBox is 300 units, rect.width is screen pixels
+  const scaleX = 300 / rect.width
+  const scaleY = 300 / rect.height
+
+  // Calculate new pan offset (subtract because we're moving the viewBox, not the content)
+  const newX = panOffset.value.x - (deltaX * scaleX)
+  const newY = panOffset.value.y - (deltaY * scaleY)
+
+  // Clamp pan offset to stay within bounds
+  // viewBox dimensions are 300x300, so we need to account for that
+  const bounds = panBounds.value
+
+  const clampedX = Math.max(
+    bounds.minX + 150,
+    Math.min(newX, bounds.maxX - 150)
+  )
+  const clampedY = Math.max(
+    bounds.minY + 150,
+    Math.min(newY, bounds.maxY - 150)
+  )
+
+  panOffset.value = { x: clampedX, y: clampedY }
+
+  // Update drag start for next move event
+  dragStart.value = { x: event.clientX, y: event.clientY }
+}
+
+const handleMouseUp = () => {
+  isDragging.value = false
+}
+
+const handleMouseLeave = () => {
+  // Stop dragging if mouse leaves the SVG area
+  isDragging.value = false
+}
 </script>
 
 <template>
   <div class="world-map-container">
     <svg
       class="world-map-svg"
-      viewBox="-150 -150 300 300"
+      :viewBox="viewBox"
       preserveAspectRatio="xMidYMid meet"
+      @mousedown="handleMouseDown"
+      @mousemove="handleMouseMove"
+      @mouseup="handleMouseUp"
+      @mouseleave="handleMouseLeave"
     >
       <g
         v-for="hex in hexagons"
@@ -87,9 +196,18 @@ const hexagons = computed(() => {
      300 viewBox units / 60 units per hex * 150px = 750px minimum */
   min-width: 750px;
   min-height: 750px;
+  cursor: grab;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+}
+
+.world-map-svg:active {
+  cursor: grabbing;
 }
 
 .hex-tile {
   cursor: default;
+  pointer-events: none;
 }
 </style>


### PR DESCRIPTION
Add mouse-based panning with bounded navigation to prevent scrolling beyond visible hexes. Document World Map architecture in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)